### PR TITLE
Update accentColor to get better contrast ratio

### DIFF
--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -1,6 +1,6 @@
 // NOTE: 웹팩 컬러 코드
 // https://webpack.js.org/branding/#color-palette
-$accentColor = 	#8dd6f9;
+$accentColor = 	#2868ca;
 $codeBgColor = #2b3a42;
 // NOTE: 뷰 프레스 컬러 코드
 // https://github.com/vuejs/vuepress/blob/master/packages/%40vuepress/theme-default/styles/custom-blocks.styl


### PR DESCRIPTION
`#8dd6f9` on `#ffffff` has a very low contrast ratio (1.6) – it may make readers hard to read the contents.
I suggest `#2868ca` for a better AA contrast ratio (5.35).

Before:
<img width="416" alt="Screen Shot 2019-10-02 at 3 07 56 PM" src="https://user-images.githubusercontent.com/579366/66021958-55f33c00-e527-11e9-9938-71d41248ca28.png">


After:
<img width="368" alt="Screen Shot 2019-10-02 at 3 15 08 PM" src="https://user-images.githubusercontent.com/579366/66022012-88049e00-e527-11e9-8d73-6b2b1efc88d0.png">


Thank you for the great article.