### PR TITLE
docs: fix wrong expression

### DIFF
--- a/docs/advanced/mode-config.md
+++ b/docs/advanced/mode-config.md
@@ -54,8 +54,8 @@ module.exports = (env) => {
 // package.json
 {
   "build": "webpack",
-  "development": "npm run build -- --env.mode=development",
-  "production": "npm run build -- --env.mode=production"
+  "development": "npm run build --env mode=development",
+  "production": "npm run build --env mode=production"
 }
 ```
 
@@ -78,7 +78,7 @@ webpack --env.a=10
 
 ```json
 {
-  "build": "webpack --env.a=10"
+  "build": "webpack --env a=10"
 }
 ```
 


### PR DESCRIPTION
### 일부 표현 수정

[advanced/mode-config](https://joshua1988.github.io/webpack-guide/advanced/mode-config.html#%EC%8B%A4%ED%96%89-%EB%AA%A8%EB%93%9C%EC%97%90-%EB%94%B0%EB%9D%BC-%EC%9B%B9%ED%8C%A9-%EC%84%A4%EC%A0%95-%EB%8B%AC%EB%A6%AC%ED%95%98%EA%B8%B0)에 적힌 예시 중 잘못된 부분을 수정했습니다.  

수정된 방식은 `env.foo=var`를 `--env foo=var` 같은 형식으로 수정했습니다.  
이 표현은 웹팩5와 웹팩4가 동일하므로 별도의 버전에 관한 언급은 하지 않았습니다. [웹팩4 environment doc](https://v4.webpack.js.org/guides/environment-variables/)
