### PR TITLE
Update webpack-merge.md

### DIFF
--- a/docs/advanced/webpack-merge.md
+++ b/docs/advanced/webpack-merge.md
@@ -38,7 +38,7 @@ module.exports = {
 
 ```js
 // webpack.dev.js
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
@@ -52,7 +52,7 @@ module.exports = merge(common, {
 
 ```js
 // webpack.prod.js
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {


### PR DESCRIPTION
webpack-merge 버전5부터는 import 방식이 바뀌었습니다.

```js
변경 전
const merge = require('webpack-merge');
```

```js
변경 후
const { merge } = require('webpack-merge');
```